### PR TITLE
Enable caching when gocdb is down

### DIFF
--- a/dashboard/dashy_endpoints.py
+++ b/dashboard/dashy_endpoints.py
@@ -9,6 +9,7 @@ from urllib import parse
 import defusedxml.ElementTree as ElementTree
 import requests
 import yaml
+from pathlib import Path
 
 DEFAULT_ICON = (
     "https://github.com/openstack/openstackdocstheme/blob/master"
@@ -17,6 +18,7 @@ DEFAULT_ICON = (
 GOCDB_PUBLICURL = "https://goc.egi.eu/gocdbpi/public/"
 DOCS_URL = "https://docs.egi.eu/users/compute/cloud-compute/openstack/"
 TIMEOUT = 10
+DASHY_OUTOUT = "dashy.output"
 
 
 def get_sites():
@@ -119,19 +121,29 @@ def main():
             "hideForGuests": False,
         },
     }
-    endpoints = find_endpoints("org.openstack.horizon")
-    items = dashy_conf["sections"][0]["items"]
-    for s in endpoints:
-        items.append(
-            {
-                "title": s[0],
-                "description": "%s (%s)" % (s[3], s[4]),
-                "icon": DEFAULT_ICON,
-                "url": s[2],
-                "target": "newtab",
-            }
-        )
-    print(yaml.dump(dashy_conf))
+    try:
+        endpoints = find_endpoints("org.openstack.horizon")
+        items = dashy_conf["sections"][0]["items"]
+        for s in endpoints:
+            items.append(
+                {
+                    "title": s[0],
+                    "description": "%s (%s)" % (s[3], s[4]),
+                    "icon": DEFAULT_ICON,
+                    "url": s[2],
+                    "target": "newtab",
+                }
+            )
+        print(yaml.dump(dashy_conf))
+        with open(DASHY_OUTOUT, 'w') as f:
+            yaml.dump(dashy_conf, f)
+    except Exception:
+        if Path(DASHY_OUTOUT).is_file():
+            with open(DASHY_OUTOUT) as f:
+                print(yaml.dump(yaml.safe_load(f)))
+        else:
+            # to-do: write in dashy_conf: "site not available at the moment"
+            print(yaml.dump(dashy_conf))
 
 
 if __name__ == "__main__":

--- a/dashboard/dashy_endpoints.py
+++ b/dashboard/dashy_endpoints.py
@@ -4,12 +4,12 @@
 This code has been copied from https://github.com/tdviet/fedcloudclient
 """
 
+from pathlib import Path
 from urllib import parse
 
 import defusedxml.ElementTree as ElementTree
 import requests
 import yaml
-from pathlib import Path
 
 DEFAULT_ICON = (
     "https://github.com/openstack/openstackdocstheme/blob/master"
@@ -135,7 +135,7 @@ def main():
                 }
             )
         print(yaml.dump(dashy_conf))
-        with open(DASHY_OUTOUT, 'w') as f:
+        with open(DASHY_OUTOUT, "w") as f:
             yaml.dump(dashy_conf, f)
     except Exception:
         if Path(DASHY_OUTOUT).is_file():


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

When GOCDB is down the dashboard doesn't work. Let's cache the output in a file that can be used while GOCDB is restored.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
