### PR TITLE
try enclosing --extra-vars ACCESS_TOKEN with double quotes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -124,7 +124,7 @@ jobs:
             ${{ steps.public_ip.outputs.stdout }}
           requirements: galaxy-requirements.yaml
           options: |
-            --extra-vars ACCESS_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+            --extra-vars ACCESS_TOKEN="$(mytoken AT --MT-env MYTOKEN)"
             --extra-vars git_ref=${{ github.sha }}
             --ssh-common-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
             -u egi


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Solving:

```
ansible-playbook: error: unrecognized arguments: AT --MT-env MYTOKEN)
```

xref: https://github.com/EGI-Federation/fedcloud-dashboard/actions/runs/10937554687/job/30363688834

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
