### PR TITLE
Use GITHUB_ENV for OIDC_TOKEN

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Install environment
+        env:
+          MYTOKEN: ${{ secrets.MYTOKEN }}
         run: |
           curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > jq
           chmod +x jq

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,9 +36,12 @@ jobs:
             > ~/.mytoken/config.yaml
           # add PWD to the PATH
           echo "$PWD" >> "$GITHUB_PATH"
+          # add OIDC access token to ENV
+          OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+          echo "::add-mask::$OIDC_TOKEN"
+          echo "OIDC_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
       - name: Configure providers access
         env:
-          MYTOKEN: ${{ secrets.MYTOKEN }}
         run: |
           cd deployment
           ./site-config.sh
@@ -113,8 +116,6 @@ jobs:
       - name: Configure with ansible
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: dawidd6/action-ansible-playbook@v2
-        env:
-          MYTOKEN: ${{ secrets.MYTOKEN }}
         with:
           playbook: playbook.yaml
           directory: ./deployment
@@ -124,7 +125,7 @@ jobs:
             ${{ steps.public_ip.outputs.stdout }}
           requirements: galaxy-requirements.yaml
           options: |
-            --extra-vars ACCESS_TOKEN="$(mytoken AT --MT-env MYTOKEN)"
+            --extra-vars ACCESS_TOKEN=${{ env.OIDC_TOKEN }}
             --extra-vars git_ref=${{ github.sha }}
             --ssh-common-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
             -u egi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,6 @@ jobs:
           echo "::add-mask::$OIDC_TOKEN"
           echo "OIDC_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
       - name: Configure providers access
-        env:
         run: |
           cd deployment
           ./site-config.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,7 @@ jobs:
           # add PWD to the PATH
           echo "$PWD" >> "$GITHUB_PATH"
           # add OIDC access token to ENV
-          OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+          OIDC_TOKEN=$(./mytoken AT --MT-env MYTOKEN)
           echo "::add-mask::$OIDC_TOKEN"
           echo "OIDC_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
       - name: Configure providers access

--- a/deployment/site-config.sh
+++ b/deployment/site-config.sh
@@ -6,18 +6,18 @@ set -e
 # Reads from config.yaml the clouds to use
 
 dump_config() {
-    # dumps a piece of yaml ready to be included in the
-    # clouds.yaml Openstack client config
-    cloud_name="$1"
-    site="$2"
-    vo="$3"
-    oidc_token="$4"
-    token="$(fedcloud openstack token issue \
-                      --oidc-access-token "$oidc_token" \
-                      --site "$site" --vo "$vo" -j \
-                      | jq -r '.[0].Result.id')"
-    eval "$(fedcloud site show-project-id --site "$site" --vo "$vo")"
-    cat << EOF
+	# dumps a piece of yaml ready to be included in the
+	# clouds.yaml Openstack client config
+	cloud_name="$1"
+	site="$2"
+	vo="$3"
+	oidc_token="$4"
+	token="$(fedcloud openstack token issue \
+		--oidc-access-token "$oidc_token" \
+		--site "$site" --vo "$vo" -j |
+		jq -r '.[0].Result.id')"
+	eval "$(fedcloud site show-project-id --site "$site" --vo "$vo")"
+	cat <<EOF
   $cloud_name:
     auth_type: token
     auth:
@@ -30,16 +30,16 @@ EOF
 # using OIDC_TOKEN generated in .github/workflows/deploy.yaml
 
 rm -f clouds.yaml
-echo "clouds:" > tmp-clouds.yaml
+echo "clouds:" >tmp-clouds.yaml
 dump_config backend \
-            "$(yq -r .clouds.backend.site config.yaml)" \
-            "$(yq -r .clouds.backend.vo config.yaml)" \
-            "$OIDC_TOKEN" >> tmp-clouds.yaml
+	"$(yq -r .clouds.backend.site config.yaml)" \
+	"$(yq -r .clouds.backend.vo config.yaml)" \
+	"$OIDC_TOKEN" >>tmp-clouds.yaml
 
 dump_config deploy \
-            "$(yq -r .clouds.deploy.site config.yaml)" \
-            "$(yq -r .clouds.deploy.vo config.yaml)" \
-            "$OIDC_TOKEN" >> tmp-clouds.yaml
+	"$(yq -r .clouds.deploy.site config.yaml)" \
+	"$(yq -r .clouds.deploy.vo config.yaml)" \
+	"$OIDC_TOKEN" >>tmp-clouds.yaml
 
 mv tmp-clouds.yaml clouds.yaml
 mkdir -p ~/.config/openstack

--- a/deployment/site-config.sh
+++ b/deployment/site-config.sh
@@ -38,7 +38,6 @@ dump_config backend \
 	"$(yq -r .clouds.backend.vo config.yaml)" \
 	"$OIDC_TOKEN" >>tmp-clouds.yaml
 
-
 dump_config deploy \
 	"$(yq -r .clouds.deploy.site config.yaml)" \
 	"$(yq -r .clouds.deploy.vo config.yaml)" \

--- a/deployment/site-config.sh
+++ b/deployment/site-config.sh
@@ -31,10 +31,13 @@ EOF
 
 rm -f clouds.yaml
 echo "clouds:" >tmp-clouds.yaml
+
+# shellcheck disable=SC2153
 dump_config backend \
 	"$(yq -r .clouds.backend.site config.yaml)" \
 	"$(yq -r .clouds.backend.vo config.yaml)" \
 	"$OIDC_TOKEN" >>tmp-clouds.yaml
+
 
 dump_config deploy \
 	"$(yq -r .clouds.deploy.site config.yaml)" \

--- a/deployment/site-config.sh
+++ b/deployment/site-config.sh
@@ -27,9 +27,7 @@ dump_config() {
 EOF
 }
 
-OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
-
-echo "::add-mask::$OIDC_TOKEN"
+# using OIDC_TOKEN generated in .github/workflows/deploy.yaml
 
 rm -f clouds.yaml
 echo "clouds:" > tmp-clouds.yaml


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

It looks like we are not passing the correct value for the token currently:

```
TASK [grycap.motley_cue : Execute contextualise_ssh_server command] ************
fatal: [147.213.76.217]: FAILED! => {"changed": true, "cmd": ["contextualise_ssh_server", "$(mytoken"], "delta": "0:00:00.584423", "end": "2024-09-19 11:29:06.407431", "msg": "non-zero return code", "rc": 1, "start": "2024-09-19 11:29:05.823008", "stderr": "", "stderr_lines": [], "stdout": "[2024-09-19 11:29:06,369] WARNING - No trusted OP produced a user info for access token\n[2024-09-19 11:29:06,370]   ERROR - Failed to get userinfos for the provided access token", "stdout_lines": ["[2024-09-19 11:29:06,369] WARNING - No trusted OP produced a user info for access token", "[2024-09-19 11:29:06,370]   ERROR - Failed to get userinfos for the provided access token"]}
```

Trying to pass it in a different way with this PR.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
