### PR TITLE
Change ports for motley-cue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ This code relies on docker-compose to run 3 containers:
 - some python code to generate the list of endpoints
 
 The existing docker-compose file assumes you will run the code on a publicly
-accessible host with a valid name:
+accessible host with a valid name. You can create a `.env` file with the
+`DASHBOARD_HOSTNAME` variable defined with the hostname of your server and just
+start the service:
 
 ```shell
 cd /path/to/working/directory
 git clone https://github.com/EGI-Federation/fedcloud-dashboard.git
-cd fedcloud-dashboard
+echo "DASHBOARD_HOSTNAME="<your host name>"
 docker-compose up --build
 ```
 

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -33,8 +33,8 @@ resource "openstack_compute_secgroup_v2" "motley" {
   description = "Open access via ssh-oidc"
 
   rule {
-    from_port   = 8080
-    to_port     = 8080
+    from_port   = 8181
+    to_port     = 8181
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -6,7 +6,7 @@ resource "openstack_compute_instance_v2" "dashboard" {
   network {
     uuid = var.net_id
   }
-  security_groups = [openstack_compute_secgroup_v2.secgroup.name, "default"]
+  security_groups = ["default", "HTTP", "motley-cue"]
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup" {
@@ -26,6 +26,19 @@ resource "openstack_compute_secgroup_v2" "secgroup" {
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }
+}
+
+resource "openstack_compute_secgroup_v2" "motley" {
+  name        = "motley-cue"
+  description = "Open access via ssh-oidc"
+
+  rule {
+    from_port   = 8080
+    to_port     = 8080
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
 }
 
 resource "openstack_networking_floatingip_v2" "fip" {

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -6,7 +6,7 @@ resource "openstack_compute_instance_v2" "dashboard" {
   network {
     uuid = var.net_id
   }
-  security_groups = ["default", "HTTP", "motley-cue"]
+  security_groups = ["HTTP", "motley-cue"]
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup" {
@@ -31,6 +31,13 @@ resource "openstack_compute_secgroup_v2" "secgroup" {
 resource "openstack_compute_secgroup_v2" "motley" {
   name        = "motley-cue"
   description = "Open access via ssh-oidc"
+
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
 
   rule {
     from_port   = 8181

--- a/deployment/playbook.yaml
+++ b/deployment/playbook.yaml
@@ -43,6 +43,13 @@
       ansible.builtin.service:
         name: nginx
         state: restarted
+        enabled: yes
+
+    - name: Restart motley-cue
+      ansible.builtin.service:
+        name: motley-cue
+        state: restarted
+        enabled: yes
 
     - name: Checkout repo at VM
       ansible.builtin.git:

--- a/deployment/playbook.yaml
+++ b/deployment/playbook.yaml
@@ -28,6 +28,12 @@
         version: "{{ git_ref }}"
         dest: /fedcloud-dashboard
 
+    - name: env file
+      ansible.builtin.copy:
+        content: |
+          DASHBOARD_HOSTNAME=dashboard.cloud.egi.eu
+        dest: /fedcloud-dashboard/.env
+
     - name: service file
       ansible.builtin.copy:
         content: |
@@ -38,7 +44,6 @@
           Description=Dashboard
           After=docker.service
           Requires=docker.service
-
           [Service]
           Type=oneshot
           RemainAfterExit=true

--- a/deployment/playbook.yaml
+++ b/deployment/playbook.yaml
@@ -22,6 +22,28 @@
   become: yes
   gather_facts: yes
   tasks:
+    - name: Disable default site in nginx
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/default
+        state: absent
+
+    - name: Move motley-cue to a different port (nginx)
+      ansible.builtin.lineinfile:
+        path: /etc/nginx/sites-available/nginx.motley_cue
+        search_string: "8080;"
+        line: 8181;
+
+    - name: Move motley-cue to a different port (pam-ssh-oidc)
+      ansible.builtin.lineinfile:
+        path: /etc/pam.d/pam-ssh-oidc-config.ini
+        search_string: "http://localhost:8080/verify_user"
+        line: http://localhost:8181/verify_user
+
+    - name: Restart nginx
+      ansible.builtin.service:
+        name: nginx
+        state: restarted
+
     - name: Checkout repo at VM
       ansible.builtin.git:
         repo: "https://github.com/EGI-Federation/fedcloud-dashboard.git"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     image: "traefik:v2.11"
     container_name: "traefik"
     command:
-#      - "--log.level=DEBUG"
+      #- "--log.level=DEBUG"
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
@@ -14,7 +14,7 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
       - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
-#      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       - "--certificatesresolvers.myresolver.acme.email=enol.fernandez@egi.eu"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     image: "b4bz/homer:v24.05.1"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.dashboard.rule=HostRegexp(`{any:.+}`)"
+      - "traefik.http.routers.dashboard.rule=Host(`${DASHBOARD_HOSTNAME}`)"
       - "traefik.http.routers.dashboard.entrypoints=websecure"
       - "traefik.http.routers.dashboard.tls.certresolver=myresolver"
     volumes_from:


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

`motley-cue` uses `8080`, like `traefik` for the dashboard. This PR moves `motley-cue` to a different port.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
