### PR TITLE
Pin terraform-provider-openstack version to 2.1.0

### DIFF
--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-provider-openstack/openstack"
+      source  = "terraform-provider-openstack/openstack"
       version = "2.1.0"
     }
   }

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "2.1.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

These errors appear after merging https://github.com/EGI-Federation/fedcloud-dashboard/pull/66

```bash

╷
│ Error: Invalid resource type
│ 
│   on main.tf line 12, in resource "openstack_compute_secgroup_v2" "secgroup":
│   12: resource "openstack_compute_secgroup_v2" "secgroup" {
│ 
│ The provider terraform-provider-openstack/openstack does not support
│ resource type "openstack_compute_secgroup_v2".
╵
╷
│ Error: Invalid resource type
│ 
│   on main.tf line 31, in resource "openstack_compute_secgroup_v2" "motley":
│   31: resource "openstack_compute_secgroup_v2" "motley" {
│ 
│ The provider terraform-provider-openstack/openstack does not support
│ resource type "openstack_compute_secgroup_v2".
╵
╷
│ Error: Invalid resource type
│ 
│   on main.tf line 55, in resource "openstack_compute_floatingip_associate_v2" "fip":
│   55: resource "openstack_compute_floatingip_associate_v2" "fip" {
│ 
│ The provider terraform-provider-openstack/openstack does not support
│ resource type "openstack_compute_floatingip_associate_v2".
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

Pinning the `terraform-provider-openstack` version to `2.1.0` until we find time to update terraform files to work with `3.0.0`.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
